### PR TITLE
fix: prevent SSRF in file_utils.download_file()

### DIFF
--- a/modules/file_utils.py
+++ b/modules/file_utils.py
@@ -1,5 +1,8 @@
 #file utils.py
 import os
+import socket
+import ipaddress
+from urllib.parse import urlparse
 from modules import app_constants, app_to_vectorstore,app_page_definitions,common_utils
 from modules import app_logger
 import json
@@ -12,9 +15,29 @@ app_logger = app_logger.app_logger
 work_dir = app_constants.WORKSPACE_DIRECTORY
 system_content_file = metadata_path=app_constants.SYSTEM_CONTENT_DATA
 
-def download_file(url):
+def is_safe_url(url):
+    """Reject URLs that don't use http/https or that resolve to a private,
+    loopback, link-local, or otherwise non-public address, to prevent SSRF
+    via user-supplied download URLs."""
     try:
-        response = requests.get(url)
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            return False
+        for family, _, _, _, sockaddr in socket.getaddrinfo(parsed.hostname, None):
+            ip = ipaddress.ip_address(sockaddr[0])
+            if not ip.is_global:
+                return False
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to validate URL {url}. Error: {e}")
+        return False
+
+def download_file(url):
+    if not is_safe_url(url):
+        app_logger.error(f"Refusing to download from disallowed URL: {url}")
+        return False
+    try:
+        response = requests.get(url, timeout=15)
         response.raise_for_status()
         sanitized_filename = sanitize_filename(url.split('/')[-1])
         sanitized_local_path = os.path.join(app_constants.WORKSPACE_DIRECTORY+"/docs/", sanitized_filename)


### PR DESCRIPTION
## Summary

`file_utils.download_file(url)` fetched any user-supplied URL server-side with no validation and no request timeout. It's reachable from the File Manager page's "Enter File Details Manually" form (`modules/nav_file_manager.py` → `file_utils.handle_content_update` → `perform_file_operation` → `download_file`).

This allowed a user to make the server issue arbitrary HTTP(S) requests to internal/private network targets, or to the cloud metadata endpoint (`169.254.169.254`), with the response saved to disk under `workspace/docs/` and optionally indexed into the RAG vector store via the "Learn It" action — a classic SSRF.

## Fix

Adds `is_safe_url(url)`:
- only allows `http`/`https` schemes
- resolves the hostname and rejects the request if any resolved address is not globally routable (blocks loopback, private (RFC1918), and link-local ranges — including `169.254.169.254` and `localhost`)

`download_file()` now checks this before making the request, and the `requests.get()` call now has a 15s timeout so a hung remote host can't block the app indefinitely.

## Testing

Manually verified the guard against `169.254.169.254`, `127.0.0.1`, `10.0.0.5`, and `localhost` (all rejected) and `8.8.8.8` (allowed). Confirmed the modified file still parses via `ast.parse`.

Note: this is a straightforward allowlist-by-resolved-IP check; it doesn't defend against TOCTOU/DNS-rebinding (resolving to a public IP at check time, then a private IP at request time). Happy to follow up with a stricter fix (e.g. pinning the resolved IP for the actual request) if that's a threat model you care about here.

---
*Found via an AI-assisted (Claude) security review of this repo; verified manually before opening this PR.*
