### PR TITLE
fix: remove unsafe_allow_html on user/LLM-influenced chat output (stored XSS)

### DIFF
--- a/modules/nav_query_docs.py
+++ b/modules/nav_query_docs.py
@@ -31,7 +31,7 @@ def app(message_store, current_page="nav_private_ai", use_retrieval_chain=False)
     # Manage message history
     app_st_session_utils.manage_message_history(current_page)
     greeting_message = common_utils.get_page_greeting(st.session_state['current_page'], st.session_state.get('username', ''),files_indexed)
-    st.chat_message("assistant").markdown(greeting_message, unsafe_allow_html=True)
+    st.chat_message("assistant").markdown(greeting_message)
 
     # Display chat messages
     for message in st.session_state.get("messages", []):

--- a/modules/nav_researcher.py
+++ b/modules/nav_researcher.py
@@ -54,7 +54,7 @@ def app(message_store):
     app_st_session_utils.manage_message_history(current_page)
     
     greeting_message = common_utils.get_page_greeting(st.session_state['current_page'], st.session_state.get('username', ''))
-    st.chat_message("assistant").markdown(greeting_message, unsafe_allow_html=True)
+    st.chat_message("assistant").markdown(greeting_message)
     app_st_session_utils.update_session_state('page_loaded', True)
 
 
@@ -69,7 +69,7 @@ def app(message_store):
         with st.spinner("Processing your request..."):
             if db_retriever:
                 formatted_response = app_prompt.query_llm(prompt,page=current_page, retriever=db_retriever.as_retriever(search_type="similarity", search_kwargs={"k": app_constants.RAG_K}), message_store=st.session_state['message_store'],use_retrieval_chain=True)
-                st.chat_message("assistant").markdown(formatted_response, unsafe_allow_html=True)
+                st.chat_message("assistant").markdown(formatted_response)
                 app_st_session_utils.add_message_to_session("user", prompt)
                 app_st_session_utils.add_message_to_session("assistant", formatted_response)
                 app_logger.info(f"Processed user prompt: {prompt}")


### PR DESCRIPTION
## Summary

`st.chat_message(...).markdown(..., unsafe_allow_html=True)` was used to render text that is influenced by user input / LLM output, in three places:

- `modules/nav_query_docs.py` — the assistant greeting, which interpolates the raw, unsanitized username entered on the welcome screen (`app.py`'s `request_username()`)
- `modules/nav_researcher.py` — same greeting pattern
- `modules/nav_researcher.py` — the LLM's chat response text, which can itself be influenced by content scraped from arbitrary URLs during "Go Research on Internet"

Because `unsafe_allow_html=True` was set, a username or model response containing HTML/JS (e.g. `<img src=x onerror=alert(document.cookie)>`) was rendered as live HTML for any user viewing that session — a stored XSS.

## Fix

None of these three call sites need raw HTML rendering, so this just drops `unsafe_allow_html=True` and lets Streamlit's default (safe) markdown renderer handle the content, which neutralizes embedded HTML/script tags instead of executing them.

## Testing

Verified the diff is minimal (3 call sites, no behavior change for legitimate markdown-formatted text) and confirmed via `ast.parse` that both modified files still parse correctly.

---
*Found via an AI-assisted (Claude) security review of this repo; verified manually before opening this PR.*
